### PR TITLE
RAINCATCH-652 - file-storage module initial implementation

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,37 @@
+{
+  "env": {
+    "node": true,
+    "browser": true,
+    "mocha": true
+  },
+  "extends": "eslint:recommended",
+  "rules": {
+    "array-callback-return": "warn",
+    "brace-style": ["error", "1tbs"],
+    "complexity": ["warn", 20],
+    "eqeqeq": "error",
+    "guard-for-in": "error",
+    "indent": ["error", 2],
+    "linebreak-style": ["error", "unix"],
+    "no-array-constructor": "error",
+    "no-console": "warn",
+    "no-lonely-if": "warn",
+    "no-loop-func": "warn",
+    "no-mixed-spaces-and-tabs": ["error"],
+    "no-nested-ternary": "error",
+    "no-spaced-func": "error",
+    "no-trailing-spaces": "error",
+    "semi": ["error", "always"],
+    "space-before-blocks": "error",
+    "space-before-function-paren": ["error", "never"],
+    "keyword-spacing": ["error"],
+    "curly": ["error", "all"]
+  },
+  "globals": {
+    "angular": false,
+    "$fh": false,
+    "FileTransfer": false,
+    "FileUploadOptions": false
+  }
+}
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+npm-debug.log
+.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+language: node_js
+node_js:
+  - '0.10'
+  - '4.4'
+sudo: false
+before_install:
+  - npm install -g npm@2.13.5
+  - npm install -g grunt@0.4.5
+  - npm install -g grunt-cli
+install: npm install
+services:
+  - docker
+script:
+  - npm test
+  - bash <(curl https://gist.githubusercontent.com/raincatcher-bot/01ac4cdb3b0770bdb58489dbc17ed6b6/raw/6205a628c3616f6736fd866d5f0fba0a781ec1e4/sonarqube.sh)
+notifications:
+  email: false
+  slack:
+    on_success: change
+    on_failure: always
+    rooms:
+      secure: >-
+        qrcxApjaQtD/vHsvkApXF8KBPncxPfDZmQSSWktGKuReC5MjJjPSHn658/jRNVxzJfL7Bp0TvQmVsBFNnmlXrw97p7r9rM4zOJRFMRXHXO9q7pjS/bDiJAck5nrKMBmCQfkgy+TxIO6aKErso/T8VJSJJgAP8FCbtYGrkqcvHBZka0Migy1+hyJ56+KdogTlGMSyQqAQPLzFLcwr9v7Sf/xAY2Hok0WSkpdcH4AUld9p2N5U+IZ12E2Szb9GtZmsNqL/3OzqOOWomAguXsgzxz1Morg947d9g95EStO7TlwqYu0IKo8JljmKj6k6Mu7Q2KPViPEJfTxMe0F3OJj2pAoBrM4ZZrGmr8NdNbU5YiqiWly2Z5Jwx8P8gC7HEcX89YrBzvAen1MVFLAxjnaRsca2UdwdcPdNHi67Xl6tPm4u8JE3UYzh6Wj0JO5BPDLzzvaTpzqbZTX6EvydOrwByKfRj0cfHUYInhezYoVMQa5s3sRYOTReTOvxoyoLJFY8Tv3gmRC75JIFszDz6XaWjmP8IFEyPnjo6QSTF61c6jRHJwtXgyXKwih9zbVvNgm559bmIYZBnxC36zoWde/o3WynY0EKLxjqkKyu8Lccmo9172s0rQFlC2SCmI8bUaDjClHWNUXIsscUa6NfvTJ6oget978jtdTqdxQQDSq66Do=
+    on_pull_requests: false
+

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,27 @@
+module.exports = function(grunt){
+  'use strict';
+  require('load-grunt-tasks')(grunt);
+  grunt.initConfig({
+    eslint: {
+      options: {
+        configFile: '.eslintrc'
+      },
+      target: ["lib/**/*.js"]
+    },
+    mochify: {
+      options: {
+        reporter: 'spec'
+      },
+      unit: {
+        src: ['lib/**/*-spec.js']
+      }
+    },
+    wfmTemplate: {
+      module: "wfm.file.directives",
+      templateDir: "lib/angular/templates",
+      outputDir: "lib/angular/dist-templates"
+    }
+  });
+  grunt.registerTask('eslint', ['eslint']);
+  grunt.registerTask('test', ['mochify:unit']);
+};

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+Copyright (c) 2016 Red Hat
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,82 @@
 # FeedHenry RainCatcher file storage [![Build Status](https://travis-ci.org/feedhenry-raincatcher/raincatcher-file-storage.png)](https://travis-ci.org/feedhenry-raincatcher/raincatcher-file-storage)
 
 A module for FeedHenry RainCatcher that manages file storage
+
+## Supported storage engines
+
+### AWS S3 storage
+
+Allows to store files in AWS S3 buckets.
+
+Options:
+
+```
+var storageConfig = {
+  s3: {
+    s3Options: {
+      accessKeyId: process.env.AWS_S3_ACCESS_KEY,
+      secretAccessKey: process.env.AWS_S3_ACCESS_KEY_SECRET,
+      region: process.env.AWS_S3_REGION
+    },
+    bucket: "raincatcher-files"
+  }
+}
+require('fh-wfm-file-storage/lib/cloud')(mediator, storageConfig);
+```
+
+### Gridfs MongoDB storage
+
+Allows to store file in MongoDB database using Gridfs driver
+
+Options:
+```
+var storageConfig = {
+  gridFs: {
+    mongoUrl: "mongodb://localhost:27017/files"
+  }
+};
+require('fh-wfm-file-storage/lib/cloud')(mediator, storageConfig);
+```
+
+### Topic Subscriptions
+
+Topics are used in file module.
+
+#### wfm:files:create
+
+##### Description
+
+Save file to the storage
+
+##### Example
+
+
+```javascript
+var parameters = {
+   // File namespace (folder)
+   namespace:null,
+   fileName:"test",
+   location: "/tmp/file"
+  //Optional topic unique identifier
+  topicUid: "uniquetopicid"
+}
+
+mediator.publish("wfm:files-store:create", parameters);
+```
+
+#### wfm:files:get
+##### Description
+
+Retrieve file from the storage (BinaryStream)
+
+##### Example
+
+```javascript
+var parameters = {
+  namespace:null,
+  fileName:"test",
+  topicUid: "uniquetopicid"
+}
+
+mediator.publish("wfm:files-store:get", parameters);
+```

--- a/lib/client/index.js
+++ b/lib/client/index.js
@@ -1,0 +1,1 @@
+// TODO Add code to support offline storage capabilities for client applications.

--- a/lib/cloud/file-storage/awsStorage.js
+++ b/lib/cloud/file-storage/awsStorage.js
@@ -1,16 +1,39 @@
 var q = require('q');
 var s3 = require('s3');
 var path = require('path');
+var CONSTANTS = require('../../constants');
 
 var config;
 var awsClient;
 
+/**
+ * Init module
+ *
+ * @param storageConfiguration configuration that should be passed from client
+ *
+ * var storageConfig = {
+ *   s3: {
+ *     s3Options: {
+ *       accessKeyId: process.env.AWS_S3_ACCESS_KEY,
+ *       secretAccessKey: process.env.AWS_S3_ACCESS_KEY_SECRET,
+ *       region: process.env.AWS_S3_REGION
+ *     },
+ *     bucket: "raincatcher-files"
+ *   }
+ * }
+ */
 function init(storageConfiguration) {
   config = storageConfiguration;
   validateConfig();
   awsClient = s3.createClient(config);
 }
-
+/**
+ * Write file to the storage
+ *
+ * @param {string} namespace - location (folder) used to place saved file.
+ * @param {string} fileName - filename that should be unique within namespace
+ * @param {string} fileLocation - local filesystem location to the file
+ */
 function writeFile(namespace, fileName, fileLocation) {
   var file;
   if (namespace) {
@@ -21,7 +44,7 @@ function writeFile(namespace, fileName, fileLocation) {
   
   var params = {
     localFile: fileLocation,
-    ACL: 'authenticated-read',
+    ACL: CONSTANTS.AWS_BUCKET_PERMISSIONS,
     s3Params: {
       Bucket: config.bucket,
       Key: file
@@ -34,14 +57,18 @@ function writeFile(namespace, fileName, fileLocation) {
     console.log(err);
     deferred.reject(err.stack);
   });
-  uploader.on('progress', function() {
-  });
   uploader.on('end', function() {
     deferred.resolve(fileName);
   });
   return deferred.promise;
 }
-
+/**
+ * Retrieve file stream from storage
+ *
+ * @param {string} namespace - location (folder) used to place saved file.
+ * @param {string} fileName - filename that should be unique within namespace
+ *
+ */
 function streamFile(namespace, fileName) {
   var file;
   if (namespace) {
@@ -55,8 +82,8 @@ function streamFile(namespace, fileName) {
     Key: file
   };
   try {
-    var buffer = awsClient.downloadStream(paramsStream);
-    deferred.resolve(buffer);
+    var stream = awsClient.downloadStream(paramsStream);
+    deferred.resolve(stream);
   } catch (error) {
     console.log(error);
     deferred.reject(error);

--- a/lib/cloud/file-storage/awsStorage.js
+++ b/lib/cloud/file-storage/awsStorage.js
@@ -1,0 +1,75 @@
+var q = require('q');
+var s3 = require('s3');
+var path = require('path');
+
+var config;
+var awsClient;
+
+function init(storageConfiguration) {
+  config = storageConfiguration;
+  awsClient = s3.createClient(config);
+}
+
+function writeFile(namespace, fileName, fileLocation) {
+  var file;
+  if (namespace) {
+    file = path.join(namespace, fileName);
+  } else {
+    file = fileName;
+  }
+  
+  var params = {
+    localFile: fileLocation,
+    ACL: 'authenticated-read',
+    s3Params: {
+      Bucket: config.bucket,
+      Key: file
+    }
+  };
+  
+  var deferred = q.defer();
+  var uploader = awsClient.uploadFile(params);
+  uploader.on('error', function(err) {
+    console.log(err);
+    deferred.reject(err.stack);
+  });
+  uploader.on('progress', function() {
+  });
+  uploader.on('end', function() {
+    deferred.resolve(fileName);
+  });
+  return deferred.promise;
+}
+
+function streamFile(namespace, fileName) {
+  var file;
+  if (namespace) {
+    file = path.join(namespace, fileName);
+  } else {
+    file = fileName;
+  }
+  var deferred = q.defer();
+  var paramsStream = {
+    Bucket: config.bucket,
+    Key: file
+  };
+  try {
+    var buffer = awsClient.downloadStream(paramsStream);
+    deferred.resolve(buffer);
+  }
+  catch (error) {
+    console.log(error);
+    deferred.reject(error);
+  }
+  return deferred.promise;
+}
+/**
+ * Implements storage interface for AWS S3 storage
+ *
+ * @type {{init: function, writeFile: function, streamFile: function}}
+ */
+module.exports = {
+  init: init,
+  writeFile: writeFile,
+  streamFile: streamFile
+}

--- a/lib/cloud/file-storage/awsStorage.js
+++ b/lib/cloud/file-storage/awsStorage.js
@@ -7,6 +7,7 @@ var awsClient;
 
 function init(storageConfiguration) {
   config = storageConfiguration;
+  validateConfig();
   awsClient = s3.createClient(config);
 }
 
@@ -56,13 +57,28 @@ function streamFile(namespace, fileName) {
   try {
     var buffer = awsClient.downloadStream(paramsStream);
     deferred.resolve(buffer);
-  }
-  catch (error) {
+  } catch (error) {
     console.log(error);
     deferred.reject(error);
   }
   return deferred.promise;
 }
+
+function validateConfig() {
+  if (!config.s3Options) {
+    throw Error("Invalid configuration for s3 storage");
+  }
+  if (!config.s3Options.accessKeyId) {
+    throw Error("Invalid configuration for s3 storage: Access Key missing");
+  }
+  if (!config.s3Options.secretAccessKey) {
+    throw Error("Invalid configuration for s3 storage: secretAccessKeymissing");
+  }
+  if (!config.s3Options.region) {
+    throw Error("Invalid configuration for s3 storage: region missing");
+  }
+}
+
 /**
  * Implements storage interface for AWS S3 storage
  *

--- a/lib/cloud/file-storage/gridfsStorage.js
+++ b/lib/cloud/file-storage/gridfsStorage.js
@@ -4,66 +4,91 @@ var mongo = require('mongodb');
 var Grid = require('gridfs-stream');
 var MongoClient = require('mongodb').MongoClient
 
-var gfs;
+var gfsPromise;
 
+/**
+ * Init module
+ *
+ * @param storageConfiguration configuration that should be passed from client
+ *
+ * var storageConfig = {
+ *  bucket: "raincatcher-files"
+ * }
+ */
 function init(storageConfiguration) {
   var config = storageConfiguration;
   if (!config || !config.mongoUrl) {
     throw Error("Missing mongoUrl parameter for GridFs storage");
   }
+  var deferred = q.defer();
   MongoClient.connect(config.mongoUrl, function(err, connection) {
     if (err) {
-      return console.log("Cannot connect to mongodb server. Gridfs storage will be disabled");
+      console.log("Cannot connect to mongodb server. Gridfs storage will be disabled");
+      return deferred.reject(err);
     }
-    console.log("Connected successfully to storage server");
-    gfs = Grid(connection, mongo);
+    var gfs = Grid(connection, mongo);
+    deferred.resolve(gfs);
   });
+  gfsPromise = deferred.promise;
 }
 
+/**
+ * Write file to the storage
+ *
+ * @param {string} namespace - location (folder) used to place saved file.
+ * @param {string} fileName - filename that should be unique within namespace
+ * @param {string} fileLocation - local filesystem location to the file
+ */
 function writeFile(namespace, fileName, fileLocation) {
-  if (!gfs) {
-    console.log("Gridfs not initialized");
+  if(!gfsPromise){
     return;
   }
-  var deferred = q.defer();
-  var options = {
-    filename: fileName
-  };
-  if (namespace) {
-    options.root = namespace;
-  }
-  var writeStream = gfs.createWriteStream(options);
-  writeStream.on('error', function(err) {
-    console.log('An error occurred!', err);
-    deferred.reject(err);
+  return gfsPromise.then(function(gfs) {
+    var deferred = q.defer();
+    var options = {
+      filename: fileName
+    };
+    if (namespace) {
+      options.root = namespace;
+    }
+    var writeStream = gfs.createWriteStream(options);
+    writeStream.on('error', function(err) {
+      console.log('An error occurred!', err);
+      deferred.reject(err);
+    });
+    
+    writeStream.on('close', function(file) {
+      deferred.resolve(file);
+    });
+    fs.createReadStream(fileLocation).pipe(writeStream);
+    return deferred.promise;
   });
-  
-  writeStream.on('close', function(file) {
-    deferred.resolve(file);
-  });
-  fs.createReadStream(fileLocation).pipe(writeStream);
-  return deferred.promise;
 }
 
+/**
+ * Retrieve file stream from storage
+ *
+ * @param {string} namespace - location (folder) used to place saved file.
+ * @param {string} fileName - filename that should be unique within namespace
+ *
+ */
 function streamFile(namespace, fileName) {
-  if (!gfs) {
-    console.log("Gridfs not initialized");
-    return;
-  }
-  var deferred = q.defer();
-  var options = {
-    filename: fileName
-  };
-  if (namespace) {
-    options.root = namespace;
-  }
-  
-  var readstream = gfs.createReadStream(options);
-  readstream.on('error', function(err) {
-    console.log('An error occurred when reading file from gridfs!', err);
+  return gfsPromise.then(function(gfs) {
+    var deferred = q.defer();
+    var options = {
+      filename: fileName
+    };
+    if (namespace) {
+      options.root = namespace;
+    }
+    
+    var readstream = gfs.createReadStream(options);
+    readstream.on('error', function(err) {
+      console.log('An error occurred when reading file from gridfs!', err);
+    });
+    deferred.resolve(readstream);
+    return deferred.promise;
   });
-  deferred.resolve(readstream);
-  return deferred.promise;
 }
 
 module.exports = {

--- a/lib/cloud/file-storage/gridfsStorage.js
+++ b/lib/cloud/file-storage/gridfsStorage.js
@@ -1,0 +1,30 @@
+var q = require('q');
+var config;
+
+
+function init(storageConfiguration){
+  config = storageConfiguration;
+  //TODO
+}
+
+function writeFile(namespace, fileName, fileLocation) {
+  var deferred = q.defer();
+  //TODO
+  // deferred.resolve(fileMeta);
+  // deferred.reject(error);
+  return deferred.promise;
+}
+
+function streamFile(namespace, fileName) {
+  var deferred = q.defer();
+  //TODO
+  // deferred.resolve(fileMeta);
+  // deferred.reject(error);
+  return deferred.promise;
+}
+
+module.exports = {
+  init: init,
+  writeFile: writeFile,
+  streamFile: streamFile
+}

--- a/lib/cloud/file-storage/gridfsStorage.js
+++ b/lib/cloud/file-storage/gridfsStorage.js
@@ -8,6 +8,9 @@ var gfs;
 
 function init(storageConfiguration) {
   var config = storageConfiguration;
+  if (!config || !config.mongoUrl) {
+    throw Error("Missing mongoUrl parameter for GridFs storage");
+  }
   MongoClient.connect(config.mongoUrl, function(err, connection) {
     if (err) {
       return console.log("Cannot connect to mongodb server. Gridfs storage will be disabled");

--- a/lib/cloud/file-storage/gridfsStorage.js
+++ b/lib/cloud/file-storage/gridfsStorage.js
@@ -1,25 +1,65 @@
 var q = require('q');
-var config;
+var fs = require('fs');
+var mongo = require('mongodb');
+var Grid = require('gridfs-stream');
+var MongoClient = require('mongodb').MongoClient
 
+var gfs;
 
-function init(storageConfiguration){
-  config = storageConfiguration;
-  //TODO
+function init(storageConfiguration) {
+  var config = storageConfiguration;
+  MongoClient.connect(config.mongoUrl, function(err, connection) {
+    if (err) {
+      return console.log("Cannot connect to mongodb server. Gridfs storage will be disabled");
+    }
+    console.log("Connected successfully to storage server");
+    gfs = Grid(connection, mongo);
+  });
 }
 
 function writeFile(namespace, fileName, fileLocation) {
+  if (!gfs) {
+    console.log("Gridfs not initialized");
+    return;
+  }
   var deferred = q.defer();
-  //TODO
-  // deferred.resolve(fileMeta);
-  // deferred.reject(error);
+  var options = {
+    filename: fileName
+  };
+  if (namespace) {
+    options.root = namespace;
+  }
+  var writeStream = gfs.createWriteStream(options);
+  writeStream.on('error', function(err) {
+    console.log('An error occurred!', err);
+    deferred.reject(err);
+  });
+  
+  writeStream.on('close', function(file) {
+    deferred.resolve(file);
+  });
+  fs.createReadStream(fileLocation).pipe(writeStream);
   return deferred.promise;
 }
 
 function streamFile(namespace, fileName) {
+  if (!gfs) {
+    console.log("Gridfs not initialized");
+    return;
+  }
   var deferred = q.defer();
-  //TODO
-  // deferred.resolve(fileMeta);
-  // deferred.reject(error);
+  var options = {
+    filename: fileName
+  };
+  if (namespace) {
+    options.root = namespace;
+  }
+  
+  var readstream = gfs.createReadStream(options);
+  readstream.on('error', function(err) {
+    console.log('An error occurred when reading file from gridfs!', err);
+  });
+  deferred.resolve(readstream);
   return deferred.promise;
 }
 
@@ -27,4 +67,4 @@ module.exports = {
   init: init,
   writeFile: writeFile,
   streamFile: streamFile
-}
+};

--- a/lib/cloud/file-storage/index.js
+++ b/lib/cloud/file-storage/index.js
@@ -1,0 +1,26 @@
+var gridfsStorage = require('./gridfsStorage');
+var s3Storage = require('./awsStorage');
+
+var client;
+
+/**
+ *
+ * Initialising the storage engine
+ *
+ * @param config
+ * @returns {StorageEngine}
+ */
+module.exports = function(config) {
+  if (!client) {
+    if (config.s3) {
+      client = s3Storage;
+      client.init(config.s3);
+    } else if (config.gridFs) {
+      client = gridfsStorage;
+      client.init(config.gridFs);
+    } else {
+      throw Error("Invalid configuration passed to the module", config);
+    }
+  }
+  return client;
+};

--- a/lib/cloud/index.js
+++ b/lib/cloud/index.js
@@ -1,0 +1,14 @@
+var mediatorSubscribers = require('./mediator-subscribers');
+var StorageEngine = require('./file-storage');
+
+/**
+ * Initialisation of the file storage module.
+ *
+ * @param {Mediator} mediator
+ * @param {object}  config -  module configuration
+ */
+module.exports = function(mediator, config) {
+  //Initialising the subscribers to topics that the module is interested in.
+  var storageEngine = StorageEngine(config);
+  return mediatorSubscribers.init(mediator, storageEngine);
+};

--- a/lib/cloud/mediator-subscribers/create.js
+++ b/lib/cloud/mediator-subscribers/create.js
@@ -1,0 +1,34 @@
+var _ = require('lodash');
+var CONSTANTS = require('../../constants');
+
+
+/**
+ * Initialising a subscriber for creating a file.
+ *
+ * @param {object} fileEntityTopics
+ * @param fileClient
+ */
+module.exports = function createFileSubscriber(fileEntityTopics, storageClient) {
+  
+  /**
+   * Handling the file upload
+   *
+   * @param {object} parameters
+   * @returns {*}
+   */
+  return function handleCreateFileTopic(parameters) {
+    var self = this;
+    parameters = parameters || {};
+    var fileCreateErrorTopic = fileEntityTopics.getTopic(CONSTANTS.TOPICS.CREATE, CONSTANTS.ERROR_PREFIX, parameters.topicUid);
+    if (!parameters.fileName || !parameters.location) {
+      return self.mediator.publish(fileCreateErrorTopic, new Error("Invalid Data To Create A File."));
+    }
+    storageClient.writeFile(parameters.namespace, parameters.fileName, parameters.location)
+      .then(function(response) {
+        self.mediator.publish(fileEntityTopics.getTopic(CONSTANTS.TOPICS.CREATE, CONSTANTS.DONE_PREFIX, parameters.topicUid), response);
+      })
+      .catch(function(error) {
+        self.mediator.publish(fileCreateErrorTopic, error);
+      });
+  };
+};

--- a/lib/cloud/mediator-subscribers/get.js
+++ b/lib/cloud/mediator-subscribers/get.js
@@ -1,0 +1,35 @@
+var CONSTANTS = require('../../constants');
+
+/**
+ * Initialising a subscriber for fetching file.
+ *
+ * @param {object} fileEntityTopics
+ * @param fileClient
+ */
+module.exports = function getFileSubscribers(fileEntityTopics, storageClient) {
+  
+  /**
+   * Handle fetching file binary data
+   *
+   * @param {object} parameters
+   * @returns {*}
+   */
+  return function handleGetFileTopic(parameters) {
+    var self = this;
+    parameters = parameters || {};
+    var errorTopic = fileEntityTopics.getTopic(CONSTANTS.TOPICS.GET, CONSTANTS.ERROR_PREFIX, parameters.topicUid);
+
+    if (!parameters.fileName) {
+      return self.mediator.publish(errorTopic, new Error("Invalid Data To Create A File."));
+    }
+  
+    storageClient.streamFile(parameters.namespace, parameters.fileName)
+      .then(function(fileBuffer) {
+        var doneTopic = fileEntityTopics.getTopic(CONSTANTS.TOPICS.GET, CONSTANTS.DONE_PREFIX, parameters.topicUid);
+        self.mediator.publish(doneTopic, fileBuffer);
+      })
+      .catch(function(error) {
+        self.mediator.publish(errorTopic, error);
+      });
+  };
+};

--- a/lib/cloud/mediator-subscribers/index.js
+++ b/lib/cloud/mediator-subscribers/index.js
@@ -1,0 +1,42 @@
+var _ = require('lodash');
+var topicHandlers = {
+  create: require('./create'),
+  get: require('./get')
+};
+var CONSTANTS = require('../../constants');
+
+var MediatorTopicUtility = require('fh-wfm-mediator/lib/topics');
+
+var fileSubscribers;
+
+module.exports = {
+  /**
+   * Initialisation of all the topics that this module is interested in.
+   *
+   * @param  mediator
+   * @param  storageEngine
+   */
+  init: function(mediator, storageEngine) {
+    //If there is already a set of subscribers set up, then don't subscribe again.
+    if (fileSubscribers) {
+      return fileSubscribers;
+    }
+  
+    fileSubscribers = new MediatorTopicUtility(mediator);
+    fileSubscribers.prefix(CONSTANTS.TOPIC_PREFIX).entity(CONSTANTS.FILES_STORAGE_ENTITY_NAME);
+  
+    //Setting up subscribers to the file topics.
+    _.each(CONSTANTS.TOPICS, function(topicName) {
+      if (topicHandlers[topicName]) {
+        fileSubscribers.on(topicName, topicHandlers[topicName](fileSubscribers, storageEngine));
+      }
+    });
+    return fileSubscribers;
+  },
+  tearDown: function() {
+    if (fileSubscribers) {
+      fileSubscribers.unsubscribeAll();
+      fileSubscribers = null;
+    }
+  }
+};

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -5,6 +5,7 @@ module.exports = {
   ERROR_PREFIX: "error",
   DONE_PREFIX: "done",
   TOPIC_TIMEOUT: 1000,
+  AWS_BUCKET_PERMISSIONS: 'authenticated-read',
   TOPICS: {
     CREATE: "create",
     GET: "get"

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,0 +1,12 @@
+module.exports = {
+  TOPIC_PREFIX: "wfm",
+  FILES_STORAGE_ENTITY_NAME: "files-store",
+  TOPIC_SEPARATOR: ":",
+  ERROR_PREFIX: "error",
+  DONE_PREFIX: "done",
+  TOPIC_TIMEOUT: 1000,
+  TOPICS: {
+    CREATE: "create",
+    GET: "get"
+  }
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-wfm-file-storage",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "A WFM module providing file storage support",
   "repository": {
     "type": "git",
@@ -17,13 +17,15 @@
   "license": "MIT",
   "dependencies": {
     "debug": "^2.6.3",
-    "fh-wfm-mediator": "0.3.1",
     "gridfs-stream": "^1.1.1",
     "lodash": "4.7.0",
+    "mongodb": "^2.2.25",
+    "fh-wfm-mediator": "0.3.2",
     "q": "1.4.1",
     "s3": "^4.4.0"
   },
   "devDependencies": {
+    "fh-wfm-mediator": "0.3.1",
     "grunt": "0.4.5",
     "grunt-eslint": "18.1.0",
     "grunt-mochify": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "fh-wfm-file-storage",
+  "version": "0.1.0",
+  "description": "A WFM module providing file storage support",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/feedhenry-raincatcher/raincatcher-file-storage.git"
+  },
+  "scripts": {
+    "test": "grunt test"
+  },
+  "keywords": [
+    "wfm",
+    "file"
+  ],
+  "author": "feedhenry-raincatcher@redhat.com",
+  "license": "MIT",
+  "dependencies": {
+    "debug": "^2.6.3",
+    "fh-wfm-mediator": "0.3.1",
+    "lodash": "4.7.0",
+    "q": "1.4.1",
+    "s3": "^4.4.0"
+  },
+  "devDependencies": {
+    "grunt": "0.4.5",
+    "grunt-eslint": "18.1.0",
+    "grunt-mochify": "^0.3.0",
+    "load-grunt-tasks": "^3.5.2",
+    "mochify": "^2.18.1",
+    "proxyquireify": "^3.2.1",
+    "sinon": "^1.17.6",
+    "sinon-as-promised": "^4.0.2",
+    "chai": "^3.5.0",
+    "proxyquire": "^1.7.10"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "debug": "^2.6.3",
     "fh-wfm-mediator": "0.3.1",
+    "gridfs-stream": "^1.1.1",
     "lodash": "4.7.0",
     "q": "1.4.1",
     "s3": "^4.4.0"


### PR DESCRIPTION
## Motivation

Initial implementation of the file storage solution interface. 
Interface initializes different client depending on the configuration passed in application.
Supported storage engineers:

- AWS S3 storage
```
  s3: {
    s3Options: {
      accessKeyId: process.env.AWS_S3_ACCESS_KEY,
      secretAccessKey: process.env.AWS_S3_ACCESS_KEY_SECRET,
      region: process.env.AWS_S3_REGION
    },
    bucket: "raincatcher-files"
  }
```
- Gridfs storage
```
var storageConfig = {
  gridFs: {
    mongoUrl: "mongodb://localhost:27017/files"
  }
};
```

Storage engine would be enabled only when file module would have flag in config set to true:
``` 
 usePersistentStorage: true
```
If flag is set to false files would be served from temporary storage (this would be used for demo apps for convenience and simplified setup). Alternative would be to have some localFile storage engine. 

## Notes

Implementation requires local file to be cached. 
Buffer support on the way here: https://github.com/andrewrk/node-s3-client/pull/154